### PR TITLE
move functions to config

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -130,7 +130,7 @@ class Manager
          *
          * https://github.com/barryvdh/laravel-translation-manager/blob/master/src/Manager.php
          */
-        $functions = ['__'];
+        $functions = config('langmanGUI.functions', ['__']);
 
         $pattern =
             // See https://regex101.com/r/jS5fX0/3


### PR DESCRIPTION
We use other multiple functions for translating texts, so the scanner does not pick these up, moving this to config will enable us to do so.