### PR TITLE
add ignore to pattern

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -136,6 +136,7 @@ class Manager
             // See https://regex101.com/r/jS5fX0/3
             '[^\w]'. // Must not start with any alphanum or _
             '(?<!->)'. // Must not start with ->
+            '(?<!(function ))'. // Must not start with 'function '
             '('.implode('|', $functions).')'.// Must start with one of the functions
             "\(".// Match opening parentheses
             "[\'\"]".// Match " or '


### PR DESCRIPTION
Ignore places where some libs (such as gettext) or our own method definition for translations exist.